### PR TITLE
Fixes broken ReST in README.rst that breaks PyPI page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,6 @@ Customization
 Always Passing The Same Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To always set the same command line options you can use a nose.cfg or setup.cfg
-(as usual) or you can specify them in settings.py like this::
-
 To always set the same command line options you can use a `nose.cfg or
 setup.cfg`_ (as usual) or you can specify them in settings.py like this::
 


### PR DESCRIPTION
The PyPI page (http://pypi.python.org/pypi/django-nose) ReST rendering is broken, because of a duplicated paragraph in the README that causes malformed ReST.

Pull this, and then "python setup.py register" to update the PyPI metadata (temporarily change the setup.py version to 0.1.2 if you don't want to register 0.1.3 at PyPI).
