### PR TITLE
Fix https://github.com/jbalogh/django-nose/issues/51, by making plugins inherit from nose.plugins.base.Plugin

### DIFF
--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -20,14 +20,14 @@ class ResultPlugin(Plugin):
     name = "result"
 
     def options(self, parser, env):
-        # We don't have any options, and this plugin is allways
+        # We don't have any options, and this plugin is always
         # enabled, so we don't want to use superclass's options()
         # method which would add a --with-* option.
         pass
 
     def configure(self, *args, **kw_args):
         super(ResultPlugin, self).configure(*args, **kw_args)
-        self.enabled = True # force this plugin to be allways enabled
+        self.enabled = True # force this plugin to be always enabled
         
     def finalize(self, result):
         self.result = result
@@ -47,14 +47,14 @@ class DjangoSetUpPlugin(Plugin):
         self.sys_stdout = sys.stdout
 
     def options(self, parser, env):
-        # We don't have any options, and this plugin is allways
+        # We don't have any options, and this plugin is always
         # enabled, so we don't want to use superclass's options()
         # method which would add a --with-* option.
         pass
 
     def configure(self, *args, **kw_args):
         super(DjangoSetUpPlugin, self).configure(*args, **kw_args)
-        self.enabled = True # force this plugin to be allways enabled
+        self.enabled = True # force this plugin to be always enabled
 
     def begin(self):
         sys_stdout = sys.stdout


### PR DESCRIPTION
I considered adding a test to runtest.sh, by adding
    django_test 'django-admin.py test --settings=testapp.settings_with_plugins -p --verbosity 2' '0' 'showing plugins descriptions'
but that didn't work due to the 
    grep "Ran $2 test"
test in django_test.
