### PR TITLE
Add liveserver run attributes to django specific, so they don't get...

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -140,7 +140,7 @@ class BasicNoseRunner(DjangoTestSuiteRunner):
             nose_argv.extend(settings.NOSE_ARGS)
 
         # Skip over 'manage.py test' and any arguments handled by django.
-        django_opts = ['--noinput']
+        django_opts = ['--noinput', '--liveserver']
         for opt in BaseCommand.option_list:
             django_opts.extend(opt._long_opts)
             django_opts.extend(opt._short_opts)


### PR DESCRIPTION
...passed down to nose
