### PR TITLE
Change test reordering link to point to Django 1.4 docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ large schema, this can save minutes of IO.
 django-nose's own FastFixtureTestCase uses this feature, even though it
 ultimately acts more like a TestCase than a TransactionTestCase.
 
-.. _can leave the DB in an unclean state: https://docs.djangoproject.com/en/dev/topics/testing/?from=olddocs#django.test.TransactionTestCase
+.. _can leave the DB in an unclean state: https://docs.djangoproject.com/en/1.4/topics/testing/#django.test.TransactionTestCase
 
 
 Test-Only Models


### PR DESCRIPTION
TransactionTestCase characteristics and test case reordering have 
changed in Django master (1.5) so there is no point in having a
reference to a document that disagrees with what README.rst is
trying  to express.
