### PR TITLE
Fix for REUSE_DB problems

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -234,11 +234,15 @@ def _skip_create_test_db(self, verbosity=1, autoclobber=False):
 
     """
     # Notice that the DB supports transactions. Originally, this was done in
-    # the method this overrides. Django v1.2 does not have the confirm
-    # function. Added in https://code.djangoproject.com/ticket/12991.
+    # the method this overrides. The confirm method was added in Django v1.3
+    # (https://code.djangoproject.com/ticket/12991) but removed in Django v1.5
+    # (https://code.djangoproject.com/ticket/17760). In Django v1.5
+    # supports_transactions is a cached property evaluated on access.
     if callable(getattr(self.connection.features, 'confirm', None)):
+        # Django v1.3-4
         self.connection.features.confirm()
-    else:
+    elif hasattr(self, "_rollback_works"):
+        # Django v1.2 and lower
         can_rollback = self._rollback_works()
         self.connection.settings_dict['SUPPORTS_TRANSACTIONS'] = can_rollback
 


### PR DESCRIPTION
I had a look into the specific problem on my machine. The essential problem is that several db backends cache their underlying connection. The nose test runner detects whether a new database is needed by calling `cursor()` on the backend after renaming the `NAME` field of the settings dictionary which the backend uses, this fails if the database does not exist, allowing nose to decide to create the database.

Unfortunately some backends cache their underlying connection objects so if any code connects to the database (which hasn't been renamed by django-nose yet) before nose does then any subsequent `cursor()` calls will succeed (as they use the cached connection) and nose is unable to detect that the database exists. The attached code fixes that.

Fixes #76
