### PR TITLE
Python 3 fixes

### DIFF
--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -63,7 +63,7 @@ def tables_used_by_fixtures(fixture_labels, using=DEFAULT_DB_ALIAS):
             compression_formats = [parts[-1]]
             parts = parts[:-1]
         else:
-            compression_formats = compression_types.keys()
+            compression_formats = list(compression_types.keys())
 
         if len(parts) == 1:
             fixture_name = parts[0]

--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -215,7 +215,7 @@ class TestReorderer(AlwaysOnPlugin):
             # in a single list so we can make a test suite out of them:
             flattened = []
             for ((fixtures, is_exempt),
-                 fixture_bundle) in bucketer.buckets.iteritems():
+                 fixture_bundle) in bucketer.buckets.items():
                 # Advise first and last test classes in each bundle to set up
                 # and tear down fixtures and the rest not to:
                 if fixtures and not is_exempt:

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -10,3 +10,5 @@ INSTALLED_APPS = (
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+SECRET_KEY = 'secret'

--- a/testapp/settings_old_style.py
+++ b/testapp/settings_old_style.py
@@ -11,3 +11,5 @@ INSTALLED_APPS = (
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 TEST_RUNNER = 'django_nose.run_tests'
+
+SECRET_KEY = 'secret'

--- a/testapp/settings_with_plugins.py
+++ b/testapp/settings_with_plugins.py
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 
 NOSE_PLUGINS = [

--- a/testapp/settings_with_south.py
+++ b/testapp/settings_with_south.py
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 
 INSTALLED_APPS = ('south',) + INSTALLED_APPS

--- a/unittests/test_databases.py
+++ b/unittests/test_databases.py
@@ -7,7 +7,7 @@ from django_nose.runner import NoseTestSuiteRunner
 
 
 class GetModelsForConnectionTests(TestCase):
-    tables = ['test_table%d' % i for i in xrange(5)]
+    tables = ['test_table%d' % i for i in range(5)]
 
     def _connection_mock(self, tables):
         class FakeIntrospection(object):


### PR DESCRIPTION
Makes django-nose Django1.5/Python3 compatible. Includes some changes automatically made by `2to3` that are not required for Python2 but don't hurt either (assuming only Python >= 2.6 compatibility is required). This way it's not necessary to run `2to3` on the codebase.
