### PR TITLE
Compatibility with Python 3.2

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -77,9 +77,9 @@ def _get_plugins_from_settings():
 
         try:
             mod = import_module(p_mod)
-        except ImportError as e:
+        except ImportError:
             raise exceptions.ImproperlyConfigured(
-                    'Error importing Nose plugin module %s: "%s"' % (p_mod, e))
+                    'Error importing Nose plugin module %s' % (p_mod))
 
         try:
             p_class = getattr(mod, p_classname)

--- a/runtests.sh
+++ b/runtests.sh
@@ -25,9 +25,13 @@ django_test() {
     fi
 }
 
-django_test 'django-admin.py test --settings=testapp.settings' '2' 'normal settings'
-django_test 'django-admin.py test --settings=testapp.settings_with_south' '2' 'with south in installed apps'
-django_test 'django-admin.py test --settings=testapp.settings_old_style' '2' 'django_nose.run_tests format'
-django_test 'testapp/runtests.py testapp.test_only_this' '1' 'via run_tests API'
-django_test 'django-admin.py test --settings=testapp.settings_with_plugins testapp/plugin_t' '1' 'with plugins'
-django_test 'django-admin.py test --settings=testapp.settings unittests' '4' 'unittests'
+# NOTE: As of 2013-02-27, South is not compatible with Python 3, so be sure to disable it when testing with Python 3 
+PYTHON=python
+DJANGO_ADMIN=`which django-admin.py`
+
+django_test "$PYTHON $DJANGO_ADMIN test --settings=testapp.settings" '2' 'normal settings'
+django_test "$PYTHON $DJANGO_ADMIN test --settings=testapp.settings_with_south" '2' 'with south in installed apps'
+django_test "$PYTHON $DJANGO_ADMIN test --settings=testapp.settings_old_style" '2' 'django_nose.run_tests format'
+django_test "$PYTHON testapp/runtests.py testapp.test_only_this" '1' 'via run_tests API'
+django_test "$PYTHON $DJANGO_ADMIN test --settings=testapp.settings_with_plugins testapp/plugin_t" '1' 'with plugins'
+django_test "$PYTHON $DJANGO_ADMIN test --settings=testapp.settings unittests" '4' 'unittests'

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2',
         'Topic :: Software Development :: Testing'
     ]
 )

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -5,8 +5,11 @@ DATABASES = {
     }
 }
 
+SECRET_KEY="AuthenticIndianCuisine"
+
 INSTALLED_APPS = (
     'django_nose',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+

--- a/testapp/settings_old_style.py
+++ b/testapp/settings_old_style.py
@@ -5,6 +5,8 @@ DATABASES = {
     }
 }
 
+SECRET_KEY="AuthenticIndianCuisine"
+
 INSTALLED_APPS = (
     'django_nose',
 )

--- a/testapp/settings_with_plugins.py
+++ b/testapp/settings_with_plugins.py
@@ -1,4 +1,4 @@
-from settings import *
+from testapp.settings import *
 
 
 NOSE_PLUGINS = [

--- a/testapp/settings_with_south.py
+++ b/testapp/settings_with_south.py
@@ -1,4 +1,4 @@
-from settings import *
+from testapp.settings import *
 
 
 INSTALLED_APPS = ('south',) + INSTALLED_APPS

--- a/unittests/test_databases.py
+++ b/unittests/test_databases.py
@@ -7,7 +7,7 @@ from django_nose.runner import NoseTestSuiteRunner
 
 
 class GetModelsForConnectionTests(TestCase):
-    tables = ['test_table%d' % i for i in xrange(5)]
+    tables = ['test_table%d' % i for i in range(5)]
 
     def _connection_mock(self, tables):
         class FakeIntrospection(object):


### PR DESCRIPTION
Some small changes to make django-nose run on Python 3.2/Django 1.5
Highlights:
- change to try/except syntax
- hackery to make print work on Py3
- changes to local module imports
- added config "SECRET_KEY" to test settings files

Cheers!