### PR TITLE
Fix #15

### DIFF
--- a/django_nose/__init__.py
+++ b/django_nose/__init__.py
@@ -7,3 +7,7 @@ from django_nose.testcases import *
 
 # Django < 1.2 compatibility.
 run_tests = run_gis_tests = NoseTestSuiteRunner
+
+
+# Replace the default test loader.
+import django_nose.loader

--- a/django_nose/loader.py
+++ b/django_nose/loader.py
@@ -1,0 +1,20 @@
+from nose.util import tolist
+from nose.loader import defaultTestLoader
+
+
+def loadTestsFromDirMonkeyPatch(test_loader, path):
+    """
+    Monkey patch for TestLoader.loadTestsFromDir. The original
+    function is a generator but we want tests to be loaded upfront
+    in order to fix https://github.com/jbalogh/django-nose/issues/15
+    and a generator is not compatible with that.
+
+    """
+
+    return list(test_loader._originalLoadTestsFromDir(path))
+
+
+if not hasattr(defaultTestLoader, '_originalLoadTestsFromDir'):
+    defaultTestLoader._originalLoadTestsFromDir = (
+        defaultTestLoader.loadTestsFromDir)
+    defaultTestLoader.loadTestsFromDir = loadTestsFromDirMonkeyPatch


### PR DESCRIPTION
This is a hackish monkey patch, but I found no way to do this using plugins.

It fixes the (officially closed) [issue #15](https://github.com/jbalogh/django-nose/issues/15), which I and several other people were still experiencing.

The problem is reproduceable by creating a test-only model and running `./manage.py test` instead of `./manage.py test <appnames>`

This fix changes the `loadTestsFromDir` function in nose.loader.TestLoader from a lazy generator into a regular function returning a list. This makes the test modules along with their modules be imported upfront and thus be seen by Django.
