### PR TITLE
Add plugin to describe tests

### DIFF
--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -251,3 +251,14 @@ class TestReorderer(AlwaysOnPlugin):
         if self.should_bundle:
             test = self._bundle_fixtures(test)
         return test
+
+
+class PrintRightPlugin(Plugin):
+    """
+    Prints out tests like path.to:TestClass.method
+    """
+    name = 'printright'
+
+    def describeTest(self, test):
+        address = test.address()
+        return "%s:%s" % (address[1], address[2])


### PR DESCRIPTION
This may be out of scope for django-nose. But, I can't live without this plugin and hate the default way that tests are described.

With the plugin, you can add

```
NOSE_PLUGINS = [
    'django_nose.plugin.PrintRightPlugin',
]
NOSE_ARGS = ['--with-printright']
```

and get test printed out like

```
test_models:FoobarTestCase.test_something ... ok
```

which you can just copy paste to run instead of having to disinterpolate, for instance:

```
test_something (test_models.FoobarTestCase)
```
