### PR TITLE
Initialize the test client during pre-setup.

### DIFF
--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -120,6 +120,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
 
         test.testcases.disable_transaction_methods()
 
+        self.client = self.client_class()
         #self._fixture_setup()
         self._urlconf_setup()
         mail.outbox = []


### PR DESCRIPTION
Django's TransactionTestCase initializes the test client during _pre_setup(),
which FastFixtureTestCase intentionally doesn't call. While the other pieces
of _pre_setup() are copied, the initialization of the test client wasn't.
