### PR TITLE
Set up simultaneous python 2/3 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: python
 python:
   - "2.6"
   - "2.7"
+env:
+  - DJANGO=1.3.3
+  - DJANGO=1.4.1
+  - DJANGO=1.5
+matrix:
+  include:
+    - python: "3.3"
+      env: DJANGO=1.5
 before_install:
   - export PIP_USE_MIRRORS=true
   - export PIP_INDEX_URL=https://simple.crate.io/
@@ -11,7 +19,3 @@ install:
   - pip install -e .
 script:
   - ./runtests.sh
-env:
-  - DJANGO=1.3.3
-  - DJANGO=1.4.1
-  - DJANGO=1.5

--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -11,6 +11,7 @@ from django.core import serializers
 from django.db import router, DEFAULT_DB_ALIAS
 from django.db.models import get_apps
 from django.utils.itercompat import product
+import six
 
 try:
     import bz2
@@ -63,7 +64,7 @@ def tables_used_by_fixtures(fixture_labels, using=DEFAULT_DB_ALIAS):
             compression_formats = [parts[-1]]
             parts = parts[:-1]
         else:
-            compression_formats = compression_types.keys()
+            compression_formats = six.iterkeys(compression_types)
 
         if len(parts) == 1:
             fixture_name = parts[0]

--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -7,6 +7,7 @@ from django.test.testcases import TransactionTestCase, TestCase
 
 from django_nose.testcases import FastFixtureTestCase
 from django_nose.utils import process_tests, is_subclass_at_all
+import six
 
 
 class AlwaysOnPlugin(Plugin):
@@ -215,7 +216,7 @@ class TestReorderer(AlwaysOnPlugin):
             # in a single list so we can make a test suite out of them:
             flattened = []
             for ((fixtures, is_exempt),
-                 fixture_bundle) in bucketer.buckets.iteritems():
+                 fixture_bundle) in six.iteritems(bucketer.buckets):
                 # Advise first and last test classes in each bundle to set up
                 # and tear down fixtures and the rest not to:
                 if fixtures and not is_exempt:

--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -7,10 +7,11 @@ You can use... ::
 in settings.py for arguments that you want always passed to nose.
 
 """
-import new
+from __future__ import print_function
 import os
 import sys
 from optparse import make_option
+from types import MethodType
 
 from django.conf import settings
 from django.core import exceptions
@@ -78,7 +79,7 @@ def _get_plugins_from_settings():
 
         try:
             mod = import_module(p_mod)
-        except ImportError, e:
+        except ImportError as e:
             raise exceptions.ImproperlyConfigured(
                     'Error importing Nose plugin module %s: "%s"' % (p_mod, e))
 
@@ -189,7 +190,7 @@ class BasicNoseRunner(DjangoTestSuiteRunner):
             nose_argv.append('--verbosity=%s' % str(self.verbosity))
 
         if self.verbosity >= 1:
-            print ' '.join(nose_argv)
+            print(' '.join(nose_argv))
 
         result = self.run_suite(nose_argv)
         # suite_result expects the suite as the first argument.  Fake it.
@@ -280,7 +281,7 @@ def _should_create_database(connection):
     # Notice whether the DB exists, and create it if it doesn't:
     try:
         connection.cursor()
-    except StandardError:  # TODO: Be more discerning but still DB agnostic.
+    except Exception:  # TODO: Be more discerning but still DB agnostic.
         return True
     return not _reusing_db()
 
@@ -367,7 +368,7 @@ class NoseTestSuiteRunner(BasicNoseRunner):
 
                 # Each connection has its own creation object, so this affects
                 # only a single connection:
-                creation.create_test_db = new.instancemethod(
+                creation.create_test_db = MethodType(
                         _skip_create_test_db, creation, creation.__class__)
 
         Command.handle = _foreign_key_ignoring_handle

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(exclude=['testapp', 'testapp/*']),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['nose>=1.2.1', 'Django>=1.2'],
+    install_requires=['nose>=1.2.1', 'Django>=1.2', 'six>=1.3.0'],
     tests_require=['south>=0.7'],
     # This blows up tox runs that install django-nose into a virtualenv,
     # because it causes Nose to import django_nose.runner before the Django
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Testing'
     ]
 )

--- a/testapp/settings_with_plugins.py
+++ b/testapp/settings_with_plugins.py
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 
 NOSE_PLUGINS = [

--- a/testapp/settings_with_south.py
+++ b/testapp/settings_with_south.py
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 
 INSTALLED_APPS = ('south',) + INSTALLED_APPS

--- a/unittests/test_databases.py
+++ b/unittests/test_databases.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from unittest import TestCase
+from six.moves import xrange
 
 from django.db.models.loading import cache
 


### PR DESCRIPTION
This is similar to #103, but the code runs on py2.6+ and py3.3+, instead of just being converted to use py3.3.
