### PR TITLE
Removing creation.__class__ parameter. Fix  jbalogh/django-nose#122

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -374,7 +374,7 @@ class NoseTestSuiteRunner(BasicNoseRunner):
                 # Each connection has its own creation object, so this affects
                 # only a single connection:
                 creation.create_test_db = MethodType(
-                        _skip_create_test_db, creation, creation.__class__)
+                        _skip_create_test_db, creation)
 
         Command.handle = _foreign_key_ignoring_handle
 


### PR DESCRIPTION
Tested with:

Django==1.5.5
South==0.8.2
nose==1.3.0

On Python 2.7.5 and 3.3.2.

The tests executed by runtests.sh script passed.