### PR TITLE
Fix NameError during tear_down

### DIFF
--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -18,6 +18,12 @@ try:
 except ImportError:
     has_bz2 = False
 
+try:
+    file
+except NameError:
+    import io
+    file = io.IOBase
+
 
 def tables_used_by_fixtures(fixture_labels, using=DEFAULT_DB_ALIAS):
     """Act like Django's stock loaddata command, but, instead of loading data,


### PR DESCRIPTION
`file` is no longer a thing in Python 3; in which case use `io.IOBase` instead.
