### PR TITLE
add serialize attribute to _skip_create_test_db() since failed with Django 1.7 and REUSE_DB=1

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -231,7 +231,7 @@ def _foreign_key_ignoring_handle(self, *fixture_labels, **options):
             connection.close()
 
 
-def _skip_create_test_db(self, verbosity=1, autoclobber=False):
+def _skip_create_test_db(self, verbosity=1, autoclobber=False, serialize=True):
     """``create_test_db`` implementation that skips both creation and flushing
 
     The idea is to re-use the perfectly good test DB already created by an


### PR DESCRIPTION
see also django/django@08218252d8be4633ac0e94863da527d824648d63
