### PR TITLE
fixed unexpected keywords

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -243,7 +243,7 @@ def _foreign_key_ignoring_handle(self, *fixture_labels, **options):
             connection.close()
 
 
-def _skip_create_test_db(self, verbosity=1, autoclobber=False):
+def _skip_create_test_db(self, verbosity=1, autoclobber=False, **kwargs):
     """``create_test_db`` implementation that skips both creation and flushing
 
     The idea is to re-use the perfectly good test DB already created by an


### PR DESCRIPTION
Prevent django-nose failing on Django-1.7 with REUSE_DB=1 variable set.

The part of backtrace:

```
 File "/Users/alex/Projects/tipsi_django1.7/dj1.7/lib/python2.7/site-packages/django/test/runner.py", line 109, in setup_databases
return setup_databases(self.verbosity, self.interactive, **kwargs)
 File "/Users/alex/Projects/tipsi_django1.7/dj1.7/lib/python2.7/site-packages/django/test/runner.py", line 299, in setup_databases
serialize=connection.settings_dict.get("TEST_SERIALIZE", True),
```

   TypeError: _skip_create_test_db() got an unexpected keyword argument 'serialize'
