### PR TITLE
Django==1.7 REUSE_DB=1 #174; Django==1.5 Python3 skip --with-profile

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -5,6 +5,8 @@ DATABASES = {
     }
 }
 
+MIDDLEWARE_CLASSES = ()
+
 INSTALLED_APPS = (
     'django_nose',
 )


### PR DESCRIPTION
squashes #164 #167 #173

On an unrelated fix, I tried to get all builds going... but I could only get so far.

The trunk builds are broken because of django/django@8568638

The option parser was changed to argparse, and an optparse compatability layer was introduced. I don't believe the option "hacking" and renaming can be done as it is right now.

Will open it's own issue
