### PR TITLE
adding args and kwargs to _skip_create_test_db

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -243,7 +243,7 @@ def _foreign_key_ignoring_handle(self, *fixture_labels, **options):
             connection.close()
 
 
-def _skip_create_test_db(self, verbosity=1, autoclobber=False):
+def _skip_create_test_db(self, verbosity=1, autoclobber=False, *args, **kwargs):
     """``create_test_db`` implementation that skips both creation and flushing
 
     The idea is to re-use the perfectly good test DB already created by an


### PR DESCRIPTION
This is a fix in response to this error I got using Django 1.7:

  File "/usr/local/lib/python2.7/dist-packages/django_nose/runner.py", line 383, in setup_databases
    return super(NoseTestSuiteRunner, self).setup_databases()
  File "/usr/local/lib/python2.7/dist-packages/django/test/runner.py", line 109, in setup_databases
    return setup_databases(self.verbosity, self.interactive, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/test/runner.py", line 299, in setup_databases
    serialize=connection.settings_dict.get("TEST", {}).get("SERIALIZE", True),
TypeError: _skip_create_test_db() got an unexpected keyword argument 'serialize'
