### PR TITLE
Allow to set runner in command option

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -156,6 +156,10 @@ class BasicNoseRunner(DiscoverRunner):
     # Replace the builtin command options with the merged django/nose options:
     options = _get_options()
 
+    # Not add following options to nosetests
+    django_opts = ['--noinput', '--liveserver', '-p', '--pattern',
+        '--testrunner']
+
     def run_suite(self, nose_argv):
         result_plugin = ResultPlugin()
         plugins_to_add = [DjangoSetUpPlugin(self),
@@ -208,7 +212,7 @@ class BasicNoseRunner(DiscoverRunner):
             nose_argv.extend(settings.NOSE_ARGS)
 
         # Skip over 'manage.py test' and any arguments handled by django.
-        django_opts = ['--noinput', '--liveserver', '-p', '--pattern']
+        django_opts = self.django_opts[:]
         for opt in BaseCommand.option_list:
             django_opts.extend(opt._long_opts)
             django_opts.extend(opt._short_opts)

--- a/runtests.sh
+++ b/runtests.sh
@@ -47,6 +47,7 @@ django_test 'django-admin.py test --settings=testapp.settings_old_style' '2' 'dj
 django_test 'testapp/runtests.py testapp.test_only_this' '1' 'via run_tests API'
 django_test 'django-admin.py test --settings=testapp.settings_with_plugins testapp/plugin_t' '1' 'with plugins'
 django_test 'django-admin.py test --settings=testapp.settings unittests' '4' 'unittests'
+django_test 'django-admin.py test --settings=testapp.settings unittests  --testrunner=testapp.custom_runner.CustomNoseTestSuiteRunner' '4' 'unittests'
 if ! [ $(version $PYTHONVERSION) \> $(version 3.0.0) ]
 then
 # Python 3 doesn't support the hotshot profiler. See nose#842.

--- a/testapp/custom_runner.py
+++ b/testapp/custom_runner.py
@@ -1,0 +1,5 @@
+from django_nose import NoseTestSuiteRunner
+
+
+class CustomNoseTestSuiteRunner(NoseTestSuiteRunner):
+    pass


### PR DESCRIPTION
In django it is possible to set custom runner by command option `--testrunner`, not only by `settings.TEST_RUNNER`.
As django-nose test command is subclass of django command, it allows it too. But this option is also passed to `nosetests` command, and nosetests fails as it doesn't have such option.
Here is a fix.