### PR TITLE
Fix #178: optparse.OptionConflictError with Django 1.8

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -138,7 +138,7 @@ def _get_options():
     plugins_option = [o for o in options if o.get_opt_string() == '--plugins'][0]
     plugins_option._short_opts.remove('-p')
 
-    django_opts = [opt.dest for opt in BaseCommand.option_list] + ['version']
+    django_opts = [opt.dest for opt in BaseCommand.option_list] + ['version', 'verbosity']
     return tuple(o for o in options if o.dest not in django_opts and
                                        o.action != 'help')
 


### PR DESCRIPTION
    Traceback (most recent call last):
      File "./tests/manage.py", line 13, in <module>
        execute_from_command_line(sys.argv)
      File ".../lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
        utility.execute()
      File ".../lib/python2.7/site-packages/django/core/management/__init__.py", line 330, in execute
        self.fetch_command(subcommand).run_from_argv(self.argv)
      File ".../lib/python2.7/site-packages/django/core/management/commands/test.py", line 30, in run_from_argv
        super(Command, self).run_from_argv(argv)
      File ".../lib/python2.7/site-packages/django/core/management/base.py", line 378, in run_from_argv
        parser = self.create_parser(argv[0], argv[1])
      File ".../lib/python2.7/site-packages/django/core/management/base.py", line 327, in create_parser
        parser.add_option(opt)
      File ".../lib/python2.7/optparse.py", line 1021, in add_option
        self._check_conflict(option)
      File ".../lib/python2.7/optparse.py", line 996, in _check_conflict
        option)
    optparse.OptionConflictError: option -v/--verbose: conflicting option string(s): -v