### PR TITLE
Run tests on django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.8,<1.9"
 matrix:
   exclude:
     - python: "3.2"
@@ -19,6 +20,8 @@ matrix:
       env: DJANGO="Django>=1.4,<1.5"
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "2.6"
+      env: DJANGO="Django>=1.8,<1.9"
 install:
   - if [ $DJANGO = 'Django>=1.4,<1.5' -o $DJANGO = 'Django>=1.6,<1.7' ]; then pip install south; fi
   - pip install "$DJANGO"


### PR DESCRIPTION
This enables Travis tests to run on django 1.8 now that it is released