### PR TITLE
Merge nose options into Django 1.8 argparse-based options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.8,<1.9"
 matrix:
   exclude:
     - python: "3.2"
@@ -19,6 +20,8 @@ matrix:
       env: DJANGO="Django>=1.4,<1.5"
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "2.6"
+      env: DJANGO="Django>=1.8,<1.9"
 install:
   - if [ $DJANGO = 'Django>=1.4,<1.5' -o $DJANGO = 'Django>=1.6,<1.7' ]; then pip install south; fi
   - pip install "$DJANGO"


### PR DESCRIPTION
When django.core.management.base.BaseCommand includes 'use_argparse',
then nose's optparse options are merged using argparse's
parser.add_argument in BaseCommand's overriden add_arguments method.

For Django 1.7 and earlier, the current .options method is used to set
the options.

Fixes #178.  Includes #194, to prove it works on Django 1.8.  Replaces #195.
