### PR TITLE
need to flush db to deal with any fixtures/data loaded via migrations

### DIFF
--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -67,6 +67,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
                 getattr(cls, '_fb_should_setup_fixtures', True)):
                 # Iff the fixture-bundling test runner tells us we're the first
                 # suite having these fixtures, set them up:
+                cls._fixture_teardown() # deal with case of first time run, clearing out any fixtures/data loaded via migrations
                 call_command('loaddata', *cls.fixtures, **{'verbosity': 0,
                                                            'commit': False,
                                                            'database': db})


### PR DESCRIPTION
this is also a bug in django's test cases, but before the first run any fixtures/data loaded via migrations can result in foreign key violations and generally an unknown state.  fix is to call fixture teardown before loading fixture.