### PR TITLE
Fix FastFixtureTestCase to support testcases without fixtures.

### DIFF
--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -63,7 +63,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
     def _fixture_setup(cls):
         """Load fixture data, and commit."""
         for db in cls._databases():
-            if (hasattr(cls, 'fixtures') and
+            if (getattr(cls, 'fixtures', None) and
                 getattr(cls, '_fb_should_setup_fixtures', True)):
                 # Iff the fixture-bundling test runner tells us we're the first
                 # suite having these fixtures, set them up:
@@ -77,7 +77,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
     @classmethod
     def _fixture_teardown(cls):
         """Empty (only) the tables we loaded fixtures into, then commit."""
-        if hasattr(cls, 'fixtures') and \
+        if getattr(cls, 'fixtures', None) and \
            getattr(cls, '_fb_should_teardown_fixtures', True):
             # If the fixture-bundling test runner advises us that the next test
             # suite is going to reuse these fixtures, don't tear them down.


### PR DESCRIPTION
Since Django 1.7, using the `FastFixtureTestCase` without specifying a list of fixtures to use raises this exception:

    TypeError: call_command() argument after * must be a sequence, not NoneType

triggered here:
```python
call_command('loaddata', *cls.fixtures, **{'verbosity': 0,
                                                           'commit': False,
                                                           'database': db})
```

Since Django 1.7 sets `fixtures` to `None` by default, django-nose should support this possibilty too. :-)