### PR TITLE
Make fixture_tables.py compatible with python 3

### DIFF
--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -38,7 +38,7 @@ def tables_used_by_fixtures(fixture_labels, using=DEFAULT_DB_ALIAS):
             return zipfile.ZipFile.read(self, self.namelist()[0])
 
     compression_types = {
-        None:   file,
+        None:   open,
         'gz':   gzip.GzipFile,
         'zip':  SingleZipReader
     }


### PR DESCRIPTION
The `file` type was removed in Python 3, so fixture_tables.py fails to load.

problem already mentioned (and fixed) at https://github.com/django-nose/django-nose/issues/133.