### PR TITLE
Use unicode_literals future import

### DIFF
--- a/django_nose/__init__.py
+++ b/django_nose/__init__.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 VERSION = (1, 4, 0)

--- a/django_nose/__init__.py
+++ b/django_nose/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 VERSION = (1, 4, 0)
 __version__ = '.'.join(map(str, VERSION))
 

--- a/django_nose/management/commands/test.py
+++ b/django_nose/management/commands/test.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """
 Add extra options from the test runner to the ``test`` command, so that you can
 browse all the nose options from the command line.

--- a/django_nose/management/commands/test.py
+++ b/django_nose/management/commands/test.py
@@ -2,6 +2,8 @@
 Add extra options from the test runner to the ``test`` command, so that you can
 browse all the nose options from the command line.
 """
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.test.utils import get_runner
 

--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 import sys

--- a/django_nose/plugin.py
+++ b/django_nose/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import sys
 
 from nose.plugins.base import Plugin

--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """Django test runner that invokes nose.
 
 You can use... ::

--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -7,7 +7,7 @@ You can use... ::
 in settings.py for arguments that you want always passed to nose.
 
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import os
 import sys
 from optparse import make_option
@@ -25,7 +25,7 @@ try:
     from django.db.backends.base.creation import BaseDatabaseCreation
 except ImportError:
     # Django < 1.7
-    from django.db.backends.creation import BaseDatabaseCreation    
+    from django.db.backends.creation import BaseDatabaseCreation
 
 try:
     from importlib import import_module

--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django import test
 from django.conf import settings
 from django.core import cache, mail

--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 from django import test

--- a/django_nose/tools.py
+++ b/django_nose/tools.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # vim: tabstop=4 expandtab autoindent shiftwidth=4 fileencoding=utf-8
 
 """

--- a/django_nose/tools.py
+++ b/django_nose/tools.py
@@ -4,6 +4,8 @@
 Provides Nose and Django test case assert functions
 """
 
+from __future__ import unicode_literals
+
 from django.test.testcases import TransactionTestCase
 
 from django.core import mail

--- a/django_nose/utils.py
+++ b/django_nose/utils.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 def process_tests(suite, process):
     """Given a nested disaster of [Lazy]Suites, traverse to the first level
     that has setup or teardown, and do something to them.

--- a/django_nose/utils.py
+++ b/django_nose/utils.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 


### PR DESCRIPTION
I ran into a problem where `runner.py` was trying to print a filename that had unicode characters in the name of the file, and it ran into trouble. This should fix it.