### PR TITLE
Don't reinitialize a TEST_MIRROR (duplicate work) on REUSE_DB=1.

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -508,6 +508,13 @@ class NoseTestSuiteRunner(BasicNoseRunner):
                 # MySQLdb doesn't allow it, and SQLAlchemy attempts to reuse
                 # the existing connection from its pool.
                 connection.close()
+            elif (connection.settings_dict.get('TEST', {}).get('MIRROR') or
+                    connection.settings_dict.get('TEST_MIRROR')):
+                # The db.TEST.MIRROR setting (or db.TEST_MIRROR in Django 1.6
+                # and below) specifies that this is a mirror of another
+                # database. We don't need to initialize the same database
+                # twice, so skip this round.
+                pass
             else:
                 # Reset auto-increment sequences. Apparently, SUMO's tests are
                 # horrid and coupled to certain numbers.


### PR DESCRIPTION
When using REUSE_DB=1 and a setup with more than one database, where the
other databases point to the first one, using the TEST_MIRROR setting,
Nose would sqlflush both databases.

When there is lots of work or a slow link, running ALTER TABLE to reset
the auto increment on all tables can take more than a few seconds.
Before this fix, the whole process would be done a second time on the
test-mirror database -- which is the same.