### PR TITLE
Update changelog to reflect range of unsupported Django versions

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.4.4 (2016-06-27)
 ~~~~~~~~~~~~~~~~~~
 * Add Django 1.10 support
-* Drop Django 1.4, 1.7, and Python 2.6 support
+* Drop Django 1.4 - 1.7, and Python 2.6 support
 * Drop South support
 
 1.4.3 (2015-12-28)


### PR DESCRIPTION
It looks like support was dropped not just for Django 1.4 and 1.7, but also 1.5 and 1.6