### PR TITLE
Fix Read The Docs build, update paths to readthedocs.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ django-nose
     accidentally shadowing test classes.
   * Taking advantage of all the useful `nose plugins`_
 
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _nose: https://nose.readthedocs.io/en/latest/
 .. _nose plugins: http://nose-plugins.jottit.com/
 
 It also provides:
@@ -57,4 +57,4 @@ Development
 -----------
 :Code:   https://github.com/django-nose/django-nose
 :Issues: https://github.com/django-nose/django-nose/issues?state=open
-:Docs:   https://django-nose.readthedocs.org
+:Docs:   https://django-nose.readthedocs.io

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,7 @@ test`` as usual.
 See ``./manage.py help test`` for all the options nose provides, and look to
 the `nose docs`_ for more help with nose.
 
-.. _nose docs: https://nose.readthedocs.org
+.. _nose docs: https://nose.readthedocs.io/en/latest/
 
 Enabling Database Reuse
 -----------------------
@@ -185,7 +185,7 @@ setup.cfg`_ (as usual) or you can specify them in settings.py like this::
 
     NOSE_ARGS = ['--failed', '--stop']
 
-.. _nose.cfg or setup.cfg: https://nose.readthedocs.org/en/latest/usage.html#configuration
+.. _nose.cfg or setup.cfg: https://nose.readthedocs.io/en/latest/usage.html#configuration
 
 
 Custom Plugins
@@ -203,5 +203,5 @@ Just like middleware or anything else, each string must be a dot-separated,
 importable path to an actual class. Each plugin class will be instantiated and
 added to the Nose test runner.
 
-.. _make custom plugins: https://nose.readthedocs.org/en/latest/plugins.html#writing-plugins
+.. _make custom plugins: https://nose.readthedocs.io/en/latest/plugins.html#writing-plugins
 

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,4 +1,5 @@
 # Requirements for ReadTheDocs
-# None right now, but avoid installing gnureadline, etc.
 # Must be set in the RTD Admin, at:
 # https://readthedocs.org/dashboard/django-nose/advanced/
+Django>=1.10,<1.11
+nose


### PR DESCRIPTION
The Read The Docs build has been broken for nine months 😢 

http://django-nose.readthedocs.io

This add the requirements needed to make the build pass.  It also updates the paths to readthedocs.io that changed on April 27, 2016:

https://blog.readthedocs.com/securing-subdomains/