### PR TITLE
Add Django 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
         - env: TOXENV=docs
           python: "2.7"
         # Supported Python / Django versions w/ SQLite
+        - env: TOXENV=py27-django-111
+          python: "2.7"
+        - env: TOXENV=py36-django-111
+          python: "3.6"
         - env: TOXENV=py27-django-110
           python: "2.7"
         - env: TOXENV=py35-django-110
@@ -24,9 +28,13 @@ matrix:
         - env: TOXENV=py34-django-18
           python: "3.4"
         # Test with PostgreSQL
-        - env: TOXENV=py27-django-19-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-110-postgres"
+        - env: TOXENV=py27-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
           python: "2.7"
-        - env: TOXENV=py35-django-19-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-110-postgres"
+        - env: TOXENV=py36-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-111-postgres"
+          python: "3.6"
+        - env: TOXENV=py27-django-110-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-110-postgres"
+          python: "2.7"
+        - env: TOXENV=py35-django-110-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-110-postgres"
           python: "3.5"
         - env: TOXENV=py27-django-19-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-19-postgres"
           python: "2.7"
@@ -35,6 +43,10 @@ matrix:
         - env: TOXENV=py27-django-18-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-18-postgres"
           python: "2.7"
         # Test with MySQL
+        - env: TOXENV=py27-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
+          python: "2.7"
+        - env: TOXENV=py36-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-111-mysql"
+          python: "3.6"
         - env: TOXENV=py27-django-110-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-110-mysql"
           python: "2.7"
         - env: TOXENV=py35-django-110-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-110-mysql"
@@ -46,20 +58,20 @@ matrix:
         - env: TOXENV=py27-django-18-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-18-mysql"
           python: "2.7"
         # Django master is allowed to fail
-        - env: TOXENV=py27-django-master
-          python: "2.7"
         - env: TOXENV=py35-django-master
           python: "3.5"
-        - env: TOXENV=py27-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-master-mysql"
-          python: "2.7"
-        - env: TOXENV=py35-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-master-postgres"
+        - env: TOXENV=py36-django-master
+          python: "3.6"
+        - env: TOXENV=py35-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-master-mysql"
           python: "3.5"
+        - env: TOXENV=py36-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-master-postgres"
+          python: "3.6"
     allow_failures:
         # Master is allowed to fail
-        - env: TOXENV=py27-django-master
         - env: TOXENV=py35-django-master
-        - env: TOXENV=py27-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-master-mysql"
-        - env: TOXENV=py35-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-master-postgres"
+        - env: TOXENV=py36-django-master
+        - env: TOXENV=py35-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-master-mysql"
+        - env: TOXENV=py36-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-master-postgres"
 
 install:
     - pip install tox coveralls

--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -89,6 +89,10 @@ class BaseRunner(DiscoverRunner):
         '--keepdb', '--reverse', '--debug-sql',
         # 1.9 arguments
         '--parallel',
+        # 1.10 arguments
+        '--tag', '--exclude-tag',
+        # 1.11 arguments
+        '--debug-mode',
     ]
 
     #

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 
 # Latest Django
-Django==1.8.5
+Django==1.11
 
 # This project
 -e .

--- a/testapp/migrations/0001_initial.py
+++ b/testapp/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='choice',
             name='question',
-            field=models.ForeignKey(to='testapp.Question'),
+            field=models.ForeignKey(to='testapp.Question', on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -21,7 +21,7 @@ class Question(models.Model):
 class Choice(models.Model):
     """A poll answer."""
 
-    question = models.ForeignKey(Question)
+    question = models.ForeignKey(Question, on_delete=models.CASCADE)
     choice_text = models.CharField(max_length=200)
     votes = models.IntegerField(default=0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist =
-    py{27,34,35}-django-{18,19,110,master}
+    py{27,34,35}-django-{18,19,110}{,-postgres,-mysql}
+    py{27,34,35,36}-django-111{,-postgres,-mysql}
+    py{25,26}-django-master{,-postgres,-mysql}
     flake8
     docs
 skip_missing_interpreters = True
@@ -16,9 +18,10 @@ deps =
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django==1.10,<1.11
+    django-111: Django==1.11,<1.12
     django-master: https://github.com/django/django/archive/master.tar.gz
-    {py27,py34,py35}-django-{18,19,110,master}-postgres: psycopg2
-    {py27,py34,py35}-django-{18,19,110,master}-mysql: mysqlclient
+    postgres: psycopg2
+    mysql: mysqlclient
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Test Django 1.11, including test options in [Django 1.10](https://docs.djangoproject.com/en/1.11/releases/1.10/#tests) and [1.11](https://docs.djangoproject.com/en/1.11/releases/1.11/#tests)