### PR TITLE
Add Django 2.0 to TravisCI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ matrix:
     include:
         # Quality checks
         - env: TOXENV=flake8
-          python: "2.7"
+          python: "3.5"
         - env: TOXENV=docs
-          python: "2.7"
+          python: "3.5"
         # Supported Python / Django versions w/ SQLite
+        - env: TOXENV=py35-django-20
+          python: "3.5"
+        - env: TOXENV=py36-django-20
+          python: "3.6"
         - env: TOXENV=py27-django-111
           python: "2.7"
         - env: TOXENV=py36-django-111
@@ -28,6 +32,10 @@ matrix:
         - env: TOXENV=py34-django-18
           python: "3.4"
         # Test with PostgreSQL
+        - env: TOXENV=py35-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
+          python: "3.5"
+        - env: TOXENV=py36-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-111-postgres"
+          python: "3.6"
         - env: TOXENV=py27-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
           python: "2.7"
         - env: TOXENV=py36-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-111-postgres"
@@ -43,6 +51,10 @@ matrix:
         - env: TOXENV=py27-django-18-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-18-postgres"
           python: "2.7"
         # Test with MySQL
+        - env: TOXENV=py35-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
+          python: "3.5"
+        - env: TOXENV=py36-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-111-mysql"
+          python: "3.6"
         - env: TOXENV=py27-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
           python: "2.7"
         - env: TOXENV=py36-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-111-mysql"

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ recommended.  It follows the `Django's support policy`_, supporting:
 * Django 1.9 with Python 2.7, 3.4, or 3.5
 * Django 1.10 with Python 2.7, 3.4, or 3.5
 * Django 1.11 (LTS) with Python 2.7, 3.4, 3.5, or 3.6
+* Django 2.0 with Python 3.5 or 3.6
 
 .. _latest release: https://pypi.python.org/pypi/nose
 .. _Django's support policy: https://docs.djangoproject.com/en/1.8/internals/release-process/#supported-versions

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 
 # Latest Django
-Django>=1.11,<2.0
+Django>=2.0,<2.1
 
 # This project
 -e .

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from testapp.models import Question, Choice
 
 
@@ -34,7 +34,7 @@ class UsesDatabaseTestCase(TestCase):
         self.assertEqual(0, the_choice.votes)
 
 
-class UsesFixtureTestCase(TestCase):
+class UsesFixtureTestCase(TransactionTestCase):
     """Tests that use a test fixture."""
 
     fixtures = ["testdata.json"]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{27,34,35}-django-{18,19,110}{,-postgres,-mysql}
     py{27,34,35,36}-django-111{,-postgres,-mysql}
-    py{35,36}-django-master{,-postgres,-mysql}
+    py{35,36}-django-{20,master}{,-postgres,-mysql}
     flake8
     docs
 skip_missing_interpreters = True
@@ -17,8 +17,9 @@ deps =
     dj-database-url
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
-    django-110: Django==1.10,<1.11
-    django-111: Django==1.11,<1.12
+    django-110: Django>=1.10,<1.11
+    django-111: Django>=1.11,<2.0
+    django-20: Django>=2.0,<2.1
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgres: psycopg2
     mysql: mysqlclient


### PR DESCRIPTION
Add Django 2.0 with Python 3.5 and 3.6 to the test matrix. Currently [in alpha](https://www.djangoproject.com/weblog/2017/sep/22/django-20-alpha-1-released/), scheduled for December 2017 release.