### PR TITLE
Add Django 2.1 support, Python 3.7 tests, release 1.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
         - env: TOXENV=docs
           python: "3.5"
         # Supported Python / Django versions w/ SQLite
+        - env: TOXENV=py35-django-21
+          python: "3.5"
+        - env: TOXENV=py36-django-21
+          python: "3.6"
         - env: TOXENV=py35-django-20
           python: "3.5"
         - env: TOXENV=py36-django-20
@@ -32,9 +36,13 @@ matrix:
         - env: TOXENV=py34-django-18
           python: "3.4"
         # Test with PostgreSQL
-        - env: TOXENV=py35-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
+        - env: TOXENV=py35-django-21-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-21-postgres"
           python: "3.5"
-        - env: TOXENV=py36-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-111-postgres"
+        - env: TOXENV=py36-django-21-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-21-postgres"
+          python: "3.6"
+        - env: TOXENV=py35-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-20-postgres"
+          python: "3.5"
+        - env: TOXENV=py36-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-20-postgres"
           python: "3.6"
         - env: TOXENV=py27-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
           python: "2.7"
@@ -51,9 +59,13 @@ matrix:
         - env: TOXENV=py27-django-18-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-18-postgres"
           python: "2.7"
         # Test with MySQL
-        - env: TOXENV=py35-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
+        - env: TOXENV=py35-django-21-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-21-mysql"
           python: "3.5"
-        - env: TOXENV=py36-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-111-mysql"
+        - env: TOXENV=py36-django-21-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-21-mysql"
+          python: "3.6"
+        - env: TOXENV=py35-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-20-mysql"
+          python: "3.5"
+        - env: TOXENV=py36-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-20-mysql"
           python: "3.6"
         - env: TOXENV=py27-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
           python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
           python: "3.5"
         - env: TOXENV=py36-django-21
           python: "3.6"
+        - env: TOXENV=py37-django-21
+          python: "3.7"
+          sudo: required
+          dist: xenial
         - env: TOXENV=py35-django-20
           python: "3.5"
         - env: TOXENV=py36-django-20
@@ -38,62 +42,112 @@ matrix:
         # Test with PostgreSQL
         - env: TOXENV=py35-django-21-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-21-postgres"
           python: "3.5"
+          services: postgresql
         - env: TOXENV=py36-django-21-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-21-postgres"
           python: "3.6"
+          services: postgresql
+        - env: TOXENV=py37-django-21-postgres DATABASE_URL="postgres://postgres@localhost:5432/py37-django-21-postgres"
+          python: "3.7"
+          sudo: required
+          dist: xenial
+          services: postgresql
         - env: TOXENV=py35-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-20-postgres"
           python: "3.5"
+          services: postgresql
         - env: TOXENV=py36-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-20-postgres"
           python: "3.6"
+          services: postgresql
+        - env: TOXENV=py37-django-20-postgres DATABASE_URL="postgres://postgres@localhost:5432/py37-django-20-postgres"
+          python: "3.7"
+          sudo: required
+          dist: xenial
+          services: postgresql
         - env: TOXENV=py27-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-111-postgres"
           python: "2.7"
+          services: postgresql
         - env: TOXENV=py36-django-111-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-111-postgres"
           python: "3.6"
+          services: postgresql
         - env: TOXENV=py27-django-110-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-110-postgres"
           python: "2.7"
+          services: postgresql
         - env: TOXENV=py35-django-110-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-110-postgres"
           python: "3.5"
+          services: postgresql
         - env: TOXENV=py27-django-19-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-19-postgres"
           python: "2.7"
+          services: postgresql
         - env: TOXENV=py35-django-19-postgres DATABASE_URL="postgres://postgres@localhost:5432/py35-django-19-postgres"
           python: "3.5"
+          services: postgresql
         - env: TOXENV=py27-django-18-postgres DATABASE_URL="postgres://postgres@localhost:5432/py27-django-18-postgres"
           python: "2.7"
+          services: postgresql
         # Test with MySQL
         - env: TOXENV=py35-django-21-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-21-mysql"
           python: "3.5"
+          services: mysql
         - env: TOXENV=py36-django-21-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-21-mysql"
           python: "3.6"
+          services: mysql
+        - env: TOXENV=py37-django-21-mysql DATABASE_URL="mysql://travis@localhost:3306/py37-django-21-mysql"
+          python: "3.7"
+          sudo: required
+          dist: xenial
+          services: mysql
         - env: TOXENV=py35-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-20-mysql"
           python: "3.5"
+          services: mysql
         - env: TOXENV=py36-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-20-mysql"
           python: "3.6"
+          services: mysql
+        - env: TOXENV=py37-django-20-mysql DATABASE_URL="mysql://travis@localhost:3306/py37-django-20-mysql"
+          python: "3.7"
+          sudo: required
+          dist: xenial
+          services: mysql
         - env: TOXENV=py27-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-111-mysql"
           python: "2.7"
+          services: mysql
         - env: TOXENV=py36-django-111-mysql DATABASE_URL="mysql://travis@localhost:3306/py36-django-111-mysql"
           python: "3.6"
+          services: mysql
         - env: TOXENV=py27-django-110-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-110-mysql"
           python: "2.7"
+          services: mysql
         - env: TOXENV=py35-django-110-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-110-mysql"
           python: "3.5"
+          services: mysql
         - env: TOXENV=py27-django-19-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-19-mysql"
           python: "2.7"
+          services: mysql
         - env: TOXENV=py35-django-19-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-19-mysql"
           python: "3.5"
+          services: mysql
         - env: TOXENV=py27-django-18-mysql DATABASE_URL="mysql://travis@localhost:3306/py27-django-18-mysql"
           python: "2.7"
+          services: mysql
         # Django master is allowed to fail
         - env: TOXENV=py35-django-master
           python: "3.5"
         - env: TOXENV=py36-django-master
           python: "3.6"
+        - env: TOXENV=py37-django-master
+          python: "3.7"
+          sudo: required
+          dist: xenial
         - env: TOXENV=py35-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-master-mysql"
           python: "3.5"
+          language: pyth
+          services: mysql
         - env: TOXENV=py36-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-master-postgres"
           python: "3.6"
+          services: postgresql
     allow_failures:
         # Master is allowed to fail
         - env: TOXENV=py35-django-master
         - env: TOXENV=py36-django-master
+        - env: TOXENV=py37-django-master
         - env: TOXENV=py35-django-master-mysql DATABASE_URL="mysql://travis@localhost:3306/py35-django-master-mysql"
         - env: TOXENV=py36-django-master-postgres DATABASE_URL="postgres://postgres@localhost:5432/py36-django-master-postgres"
 

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ recommended.  It follows the `Django's support policy`_, supporting:
 * Django 1.10 with Python 2.7, 3.4, or 3.5
 * Django 1.11 (LTS) with Python 2.7, 3.4, 3.5, or 3.6
 * Django 2.0 with Python 3.4, 3.5 or 3.6
+* Django 2.1 with Python 3.5 or 3.6
 
 Python 3.7 should work, but is untested in TravisCI.
 

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,8 @@ recommended.  It follows the `Django's support policy`_, supporting:
 * Django 1.9 with Python 2.7, 3.4, or 3.5
 * Django 1.10 with Python 2.7, 3.4, or 3.5
 * Django 1.11 (LTS) with Python 2.7, 3.4, 3.5, or 3.6
-* Django 2.0 with Python 3.4, 3.5 or 3.6
-* Django 2.1 with Python 3.5 or 3.6
-
-Python 3.7 should work, but is untested in TravisCI.
+* Django 2.0 with Python 3.4, 3.5, 3.6, or 3.7
+* Django 2.1 with Python 3.5, 3.6, or 3.7
 
 .. _latest release: https://pypi.python.org/pypi/nose
 .. _Django's support policy: https://docs.djangoproject.com/en/1.8/internals/release-process/#supported-versions

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,9 @@ recommended.  It follows the `Django's support policy`_, supporting:
 * Django 1.9 with Python 2.7, 3.4, or 3.5
 * Django 1.10 with Python 2.7, 3.4, or 3.5
 * Django 1.11 (LTS) with Python 2.7, 3.4, 3.5, or 3.6
-* Django 2.0 with Python 3.5 or 3.6
+* Django 2.0 with Python 3.4, 3.5 or 3.6
+
+Python 3.7 should work, but is untested in TravisCI.
 
 .. _latest release: https://pypi.python.org/pypi/nose
 .. _Django's support policy: https://docs.djangoproject.com/en/1.8/internals/release-process/#supported-versions

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+1.4.6 (2018-10-03)
+~~~~~~~~~~~~~~~~~~
+* Document Django 2.0 and 2.1 support, no changes needed
+* Document Python 3.7 support
+
 1.4.5 (2017-08-22)
 ~~~~~~~~~~~~~~~~~~
 * Add Django 1.11 support

--- a/django_nose/__init__.py
+++ b/django_nose/__init__.py
@@ -8,5 +8,5 @@ assert BasicNoseRunner
 assert NoseTestSuiteRunner
 assert FastFixtureTestCase
 
-VERSION = (1, 4, 5)
+VERSION = (1, 4, 6)
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ _(Older changes can be found in the full documentation)._
 
 setup(
     name='django-nose',
-    version='1.4.5',
+    version='1.4.6',
     description='Makes your Django tests simple and snappy',
     long_description=get_long_description('django-nose'),
     author='Jeff Balogh',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -76,6 +81,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Testing'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Testing'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py{27,34,35}-django-{18,19,110}{,-postgres,-mysql}
     py{27,34,35,36}-django-111{,-postgres,-mysql}
-    py{34,35,36}-django-{20,master}{,-postgres,-mysql}
+    py{34,35,36,37}-django-20{,-postgres,-mysql}
+    py{35,36,37}-django-{21,master}{,-postgres,-mysql}
     flake8
     docs
 skip_missing_interpreters = True
@@ -20,6 +21,7 @@ deps =
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2.0
     django-20: Django>=2.0,<2.1
+    django-21: Django>=2.1,<2.2
     django-master: https://github.com/django/django/archive/master.tar.gz
     postgres: psycopg2
     mysql: mysqlclient

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{27,34,35}-django-{18,19,110}{,-postgres,-mysql}
     py{27,34,35,36}-django-111{,-postgres,-mysql}
-    py{35,36}-django-{20,master}{,-postgres,-mysql}
+    py{34,35,36}-django-{20,master}{,-postgres,-mysql}
     flake8
     docs
 skip_missing_interpreters = True


### PR DESCRIPTION
* Add Python 3.4 support in Django 2.0
* Add Python 3.7 tests in TravisCI
* Add Django classifiers
* Release 1.4.6 - just update the support docs